### PR TITLE
build: Remove include hardcode

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -27,11 +27,6 @@ cc_binary {
     static_libs: [
     	"libjsoncpp",
     ],
-    include_dirs: [
-    	"vendor/unetworking/uwebsockets/src",
-    	"external/boringssl/include",
-    	"external/zlib",
-    ],    
 	cflags: [
 		"-std=c++11",
 		"-DLOG_NDEBUG",


### PR DESCRIPTION
All menthioned header will be provided by libuws.

Signed-off-by: Andrii Chepurnyi <andrii_chepurnyi@epam.com>