### PR TITLE
Patches and fixes for Android 12

### DIFF
--- a/Gnss.cpp
+++ b/Gnss.cpp
@@ -59,7 +59,6 @@ Return<bool> Gnss::start() {
 
     mIsActive = true;
     mVis.init();
-    mVis.waitConnection(5);
     mThread = std::thread([this]() {
         while (mIsActive == true) {
             mVis.pull();

--- a/Gnss.cpp
+++ b/Gnss.cpp
@@ -269,6 +269,10 @@ Return<void> Gnss::reportLocation(const GnssLocation& location) const {
         ALOGE("%s: sGnssCallback is null.", __func__);
         return Void();
     }
+
+    if(location.timestamp != 0)
+        sGnssCallback->gnssLocationCb(location);
+
     sGnssCallback->gnssLocationCb(location);
     return Void();
 }

--- a/Gnss.cpp
+++ b/Gnss.cpp
@@ -272,7 +272,6 @@ Return<void> Gnss::reportLocation(const GnssLocation& location) const {
     if(location.timestamp != 0)
         sGnssCallback->gnssLocationCb(location);
 
-    sGnssCallback->gnssLocationCb(location);
     return Void();
 }
 

--- a/VisDataProvider.cpp
+++ b/VisDataProvider.cpp
@@ -39,7 +39,7 @@ namespace xenvm {
 
 int VisDataProvider::init() {
     char propValue[PROPERTY_VALUE_MAX] = {};
-    property_get("persist.vis.uri", propValue, "wss://wwwivi:8088");
+    property_get("persist.vendor.vis.uri", propValue, "wss://wwwivi:8088");
     mUri = propValue;
     static unsigned int requestid = 0;
     mLocation.gnssLocationFlags = 0xFF;

--- a/VisDataProvider.h
+++ b/VisDataProvider.h
@@ -21,6 +21,8 @@
 #include <android/hardware/gnss/1.0/types.h>
 #include <uWS.h>
 #include <string>
+#include "mutex"
+#include "atomic"
 
 using android::hardware::gnss::V1_0::GnssLocation;
 
@@ -43,14 +45,15 @@ class VisDataProvider {
 
     int init();
     int pull();
-    GnssLocation getLocation() const { return mLocation; }
+    GnssLocation getLocation() const;
     bool waitConnection(int s) const;
 
  private:
     std::string mUri;
     uWS::Hub mHub;
-    ConnState mConnectedState;
+    std::atomic<ConnState> mConnectedState;
     GnssLocation mLocation;
+    mutable std::recursive_mutex mProtector;
 
     static constexpr const char* paramValueName = "value";
     static constexpr const char* paramTimestampName = "timestamp";


### PR DESCRIPTION
Change vis parameter name to comply with Android 12
Change 'persist.vis.uri' to 'persist.vendor.vis.uri' in order to fit to the Android 12 properties naming convention

Reviewed-by: Andrii Chepurnyi <andrii_chepurnyi@epam.com>
Signed-off-by: Vladyslav Goncharuk <vladyslav_goncharuk@epam.com>

----

Add check to not send an empty location
Reviewed-by: Andrii Chepurnyi <andrii_chepurnyi@epam.com>
Signed-off-by: Vladyslav Goncharuk <vladyslav_goncharuk@epam.com>

----

Remove waiting for the connection to the VIS server
Remove waiting for the connection to the VIS server in order to not
block the HIDL client for too long

Reviewed-by: Andrii Chepurnyi <andrii_chepurnyi@epam.com>
Signed-off-by: Vladyslav Goncharuk <vladyslav_goncharuk@epam.com>

----

Refactor 'VisDataProvider'
Refactor 'VisDataProvider'. Remove redundant source code. Add
synchronization.

Reviewed-by: Andrii Chepurnyi <andrii_chepurnyi@epam.com>
Signed-off-by: Vladyslav Goncharuk <vladyslav_goncharuk@epam.com>